### PR TITLE
Fix field bidResponse.seatbid being required in JSON schemas for OpenRTB 2.3+

### DIFF
--- a/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-3.json
+++ b/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-3.json
@@ -3,7 +3,7 @@
 	"title": "openrtb-v2_3-schema-bid_response",
 	"description": "json schema for an openrtb v2.3 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-3.pdf)",
 	"type": "object",
-	"required": [ "id", "seatbid" ],
+	"required": [ "id" ],
 	"additionalProperties": false,
 	"properties": {
 		"id": {

--- a/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-4.json
+++ b/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-4.json
@@ -3,7 +3,7 @@
 	"title": "openrtb-v2_4-schema-bid_response",
 	"description": "json schema for an openrtb v2.4 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-4.pdf)",
 	"type": "object",
-	"required": [ "id", "seatbid" ],
+	"required": [ "id" ],
 	"additionalProperties": false,
 	"properties": {
 		"id": {

--- a/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-5.json
+++ b/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-5.json
@@ -4,8 +4,7 @@
 	"description": "json schema for an openrtb v2.5 bid response (http://www.iab.net/media/file/OpenRTB-API-Specification-Version-2-5.pdf)",
 	"type": "object",
 	"required": [
-		"id",
-		"seatbid"
+		"id"
 	],
 	"additionalProperties": false,
 	"properties": {


### PR DESCRIPTION
Starting with OpenRTB 2.3, the field `seatbid` is no longer required in bid responses and should be allowed to be omitted.
Still the JSON schemas require the field `seatbid` to be present in bid responses.
This PR fixes this.