### PR TITLE
fix broken 2.5 schemas

### DIFF
--- a/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-request_v2-5.json
+++ b/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-request_v2-5.json
@@ -449,7 +449,7 @@
 				"battr": {
 					"type": "array",
 					"items": {
-						"$ref": "#definitions/creative_attribute"
+						"$ref": "#/definitions/creative_attribute"
 					}
 				},
 				"maxextended": {
@@ -483,7 +483,7 @@
 				"companiontype": {
 					"type": "array",
 					"items": {
-						"$ref": "#definitions/vast_companion_type"
+						"$ref": "#/definitions/vast_companion_type"
 					}
 				},
 				"maxseq": {

--- a/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-5.json
+++ b/openrtb-validator/src/main/resources/schemas/openrtb-schema_bid-response_v2-5.json
@@ -28,7 +28,7 @@
 			"type": "string"
 		},
 		"nbr": {
-			"$ref": "#/definitions/nobid_reason"
+			"$ref": "#/definitions/nobid_reason_code"
 		},
 		"ext": {
 			"type": "object"


### PR DESCRIPTION
Request schema had bad references (missing /).
Response schema pointed to a bad reference `nobid_reason` instead
`nobid_reason_code`